### PR TITLE
Update webviews dynamically after user actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "entry",
 	"displayName": "entry",
 	"publisher": "entry",
-	"description": "Write notes for your code",
+	"description": "Makes it easy to write and organize notes for your code, directly in your IDE.",
 	"version": "0.0.93",
 	"engines": {
 		"vscode": "^1.83.0"

--- a/src/components/overview/overview.ts
+++ b/src/components/overview/overview.ts
@@ -86,30 +86,26 @@ export async function getWebviewOverview(webview: vscode.Webview, context: vscod
             document.querySelector("#add-folder-button").addEventListener("click", () => {
                 const globalStorageName = 'entry.entry';
                 const globalStoragePath = ${JSON.stringify(globalStoragePath)};
-                const overview = 'overview';
                 vscode.postMessage({
                     command: 'addFolder',
                     destinationFolderName: globalStorageName,
                     destinationFolderUri: globalStoragePath,
-                    webviewToRender: overview,
+                    webviewToRender: 'overview'
                 });
             });
 
             document.querySelector("#add-note-button").addEventListener("click", () => {
                 const notesFolderPath = ${JSON.stringify(globalStoragePath)} + '/Notes';
-                const overview = 'overview';
                 vscode.postMessage({
                     command: 'addNote',
                     destinationFolderUri: notesFolderPath,
-                    webviewToRender: overview,
+                    webviewToRender: 'overview'
                 });
             });
             
                 document.querySelectorAll(".move").forEach((moveButton)=>{
                     moveButton.addEventListener("mouseover", (button) => {
                         const data = ${JSON.stringify(allFolders)}
-                        const sourcePath = moveButton.getAttribute("value")
-                        const sourceFoldername = moveButton.getAttribute("name")
                         moveButton.appendChild(list(data, sourcePath, sourceFoldername));
                     }, { once: true })
                 });
@@ -119,21 +115,23 @@ export async function getWebviewOverview(webview: vscode.Webview, context: vscod
                         const oldFolderPath = renameButton.getAttribute("value");
                         const parentPath = oldFolderPath.substr(0, oldFolderPath.lastIndexOf("/"));
                         const parentFolder = parentPath.substr(parentPath.lastIndexOf("/") + 1);
-                            vscode.postMessage({
-                                command: 'renameFolder',
-                                oldFolderPath: oldFolderPath,
-                                parentPath: parentPath,
-                                parentFolder: parentFolder,
-                                webviewToRender: 'overview'
-                            });
+                        vscode.postMessage({
+                            command: 'renameFolder',
+                            oldFolderPath: oldFolderPath,
+                            parentPath: parentPath,
+                            parentFolder: parentFolder,
+                            webviewToRender: 'overview'
                         });
                     });
+                });
 
                 document.querySelectorAll(".delete-button").forEach((deleteButton) => {
                     deleteButton.addEventListener("click", () => {
                         const folderName = deleteButton.getAttribute("data-folder-name");
                         const folderPath = deleteButton.getAttribute("data-folder-path");
-                
+                        const globalStorageName = 'entry.entry';
+                        const globalStoragePath = ${JSON.stringify(globalStoragePath)};
+
                         const deleteContainer = deleteButton.closest(".item").querySelector("#delete-container");
 
                         if (deleteContainer) {
@@ -147,17 +145,18 @@ export async function getWebviewOverview(webview: vscode.Webview, context: vscod
                                         command: 'deleteFolder',
                                         folderName: folderName,
                                         folderPath: folderPath,
-                                        setPage: 'overview',
-                                        currentFolderName: folderName,
-                                        currentFolderPath: folderPath
+                                        destinationFolderName: globalStorageName,
+                                        destinationFolderUri: globalStoragePath,
+                                        webviewToRender: 'overview'
                                     });                            
                                 } else {
                                     vscode.postMessage({
                                         command: 'deleteFile',
                                         fileName: deleteButton.getAttribute("data-file-name"),
                                         filePath: deleteButton.getAttribute("data-file-path"),
-                                        setPage: 'overview',
-                                        currentFolderName: ${JSON.stringify(globalStoragePath)}
+                                        destinationFolderName: globalStorageName,
+                                        destinationFolderUri: globalStoragePath,
+                                        webviewToRender: 'overview'
                                     }); 
                                 }
                             });

--- a/src/components/overview/overview.ts
+++ b/src/components/overview/overview.ts
@@ -105,7 +105,9 @@ export async function getWebviewOverview(webview: vscode.Webview, context: vscod
             
                 document.querySelectorAll(".move").forEach((moveButton)=>{
                     moveButton.addEventListener("mouseover", (button) => {
-                        const data = ${JSON.stringify(allFolders)}
+                        const data = ${JSON.stringify(allFolders)};
+                        const sourcePath = moveButton.getAttribute("value");
+                        const sourceFoldername = moveButton.getAttribute("name");
                         moveButton.appendChild(list(data, sourcePath, sourceFoldername));
                     }, { once: true })
                 });
@@ -131,7 +133,7 @@ export async function getWebviewOverview(webview: vscode.Webview, context: vscod
                         const folderPath = deleteButton.getAttribute("data-folder-path");
                         const globalStorageName = 'entry.entry';
                         const globalStoragePath = ${JSON.stringify(globalStoragePath)};
-
+                        
                         const deleteContainer = deleteButton.closest(".item").querySelector("#delete-container");
 
                         if (deleteContainer) {

--- a/src/components/subfolder/subfolder.ts
+++ b/src/components/subfolder/subfolder.ts
@@ -81,7 +81,6 @@ export async function getWebviewSubfolder(folderData: any, webview: vscode.Webvi
                         const folderName = crumb.getAttribute('data-folder-name');
                         const path = crumb.getAttribute('folder-path');
                         if(folderName == "Overview"){
-                            console.log('navigate to overview');
                             vscode.postMessage({
                                 command: 'navigate',
                                 destinationFolderName: folderName,
@@ -89,7 +88,6 @@ export async function getWebviewSubfolder(folderData: any, webview: vscode.Webvi
                                 webviewToRender: 'overview'
                             });
                         } else {
-                            console.log('navigate to subfolder');
                             vscode.postMessage({
                                 command: 'navigate',
                                 destinationFolderName: folderName,

--- a/src/components/subfolder/subfolder.ts
+++ b/src/components/subfolder/subfolder.ts
@@ -190,18 +190,19 @@ export async function getWebviewSubfolder(folderData: any, webview: vscode.Webvi
                                         command: 'deleteFolder',
                                         folderName: folderName,
                                         folderPath: folderPath,
-                                        setPage: 'subfolder',
                                         currentFolderName: ${JSON.stringify(folderData.folderName)},
-                                        currentFolderPath: ${JSON.stringify(folderData.uriPath)}
+                                        currentFolderPath: ${JSON.stringify(folderData.uriPath)},
+                                        webviewToRender: 'subfolder'
+
                                     });                            
                                 } else {
                                     vscode.postMessage({
                                         command: 'deleteFile',
                                         fileName: deleteButton.getAttribute("data-file-name"),
                                         filePath: deleteButton.getAttribute("data-file-path"),
-                                        setPage: 'subfolder',
                                         currentFolderName: ${JSON.stringify(folderData.folderName)},
-                                        currentFolderPath: ${JSON.stringify(folderData.uriPath)}
+                                        currentFolderPath: ${JSON.stringify(folderData.uriPath)},
+                                        webviewToRender: 'subfolder'
                                     }); 
                                 }
                             });

--- a/src/components/subfolder/subfolder.ts
+++ b/src/components/subfolder/subfolder.ts
@@ -81,14 +81,20 @@ export async function getWebviewSubfolder(folderData: any, webview: vscode.Webvi
                         const folderName = crumb.getAttribute('data-folder-name');
                         const path = crumb.getAttribute('folder-path');
                         if(folderName == "Overview"){
+                            console.log('navigate to overview');
                             vscode.postMessage({
-                                page: "overview",
+                                command: 'navigate',
+                                destinationFolderName: folderName,
+                                destinationFolderUri: path,
+                                webviewToRender: 'overview'
                             });
-                        } else{
+                        } else {
+                            console.log('navigate to subfolder');
                             vscode.postMessage({
-                                page: 'subfolder',
-                                folderName: folderName,
-                                folderPath: path
+                                command: 'navigate',
+                                destinationFolderName: folderName,
+                                destinationFolderUri: path,
+                                webviewToRender: 'subfolder'
                             });
                         }
                     });
@@ -137,22 +143,26 @@ export async function getWebviewSubfolder(folderData: any, webview: vscode.Webvi
                 const parentFolder = parentUri.substr(parentUri.lastIndexOf("/") + 1);
                 if(parentFolder == "entry.entry"){
                     vscode.postMessage({
-                        page: "overview",
+                        command: 'navigate',
+                        destinationFolderName: parentFolder,
+                        destinationFolderUri: parentUri,
+                        webviewToRender: 'overview'
                     });
                 } else{
                     vscode.postMessage({
-                        page: 'subfolder',
-                        folderName: parentFolder,
-                        folderPath: parentUri
+                        command: 'navigate',
+                        destinationFolderName: parentFolder,
+                        destinationFolderUri: parentUri,
+                        webviewToRender: 'subfolder'
                     });
                 }
             });
 
                 document.querySelectorAll(".move").forEach((moveButton)=>{
                     moveButton.addEventListener("mouseover", (button)=>{
-                        const data = ${JSON.stringify(allFolders)}
-                        const sourcePath = moveButton.getAttribute("value")
-                        const sourceFoldername = moveButton.getAttribute("name")
+                        const data = ${JSON.stringify(allFolders)};
+                        const sourcePath = moveButton.getAttribute("value");
+                        const sourceFoldername = moveButton.getAttribute("name");
                         moveButton.appendChild(list(data, sourcePath, sourceFoldername));
                     }, { once: true })
                 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,11 +51,16 @@ export async function activate(context: vscode.ExtensionContext) {
 				switch (message.command) {
 					case "move":
 						moveToFolder(message.pathTo, message.pathFrom);
-						console.log('Move!');
+						panel.webview.html = await updateWebview(
+							message.destinationFolderName,
+							message.destinationFolderUri,
+							message.webviewToRender,
+							panel.webview,
+							context
+						);
 						return;
 					case "search":
 						panel.webview.html = await search(message.searchTerm, panel.webview, context);
-						console.log('Search!');
 						return;
 					case "addFolder":
 						await addFolder(message.destinationFolderName, message.destinationFolderUri, message.webviewToRender, context, panel);
@@ -66,12 +71,10 @@ export async function activate(context: vscode.ExtensionContext) {
 							panel.webview,
 							context
 						);
-						console.log('Add Folder!');
 						return;
 					case "renameFolder":
 						await renameFolder(message.oldFolderPath);
 						panel.webview.html = await updateWebview(message.parentFolder, message.parentPath, message.webviewToRender, panel.webview, context);
-						console.log('Rename!');
 						return;
 					case "addNote":
 						await addNote(message.destinationFolderName, message.destinationFolderUri, message.webviewToRender, context, panel);
@@ -82,7 +85,6 @@ export async function activate(context: vscode.ExtensionContext) {
 							panel.webview,
 							context
 						);
-						console.log('Add note!');
 						return;
 					case "save":
 						await saveFile(message.fileName, message.filePath, message.data.fileContent, context);
@@ -95,7 +97,6 @@ export async function activate(context: vscode.ExtensionContext) {
 						);
 						currentOpenFile = "";
 						currentOpenFilePath = "";
-						console.log('Save!');
 						return;
 					case "deleteFile":
 						await deleteFile(
@@ -110,7 +111,6 @@ export async function activate(context: vscode.ExtensionContext) {
 							panel.webview,
 							context
 						);
-						console.log('Delete file!');
 						return;
 					case "deleteFolder":
 						await deleteFolder(
@@ -125,11 +125,19 @@ export async function activate(context: vscode.ExtensionContext) {
 								panel.webview,
 								context
 							);
-						console.log('Delete folder!');
 						return;
 					case "comment":
 						addDecoratorToLine(panel.webview, context, message.fileName, message.filePath);
-						console.log('Link code inside note!');
+						return;
+					case "navigate":
+						panel.webview.html = await updateWebview(
+							message.destinationFolderName,
+							message.destinationFolderUri,
+							message.webviewToRender,
+							panel.webview,
+							context
+						);
+						return;
 				}
 			},
 			undefined,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,9 +51,11 @@ export async function activate(context: vscode.ExtensionContext) {
 				switch (message.command) {
 					case "move":
 						moveToFolder(message.pathTo, message.pathFrom);
+						console.log('Move!');
 						return;
 					case "search":
 						panel.webview.html = await search(message.searchTerm, panel.webview, context);
+						console.log('Search!');
 						return;
 					case "addFolder":
 						await addFolder(message.destinationFolderName, message.destinationFolderUri, message.webviewToRender, context, panel);
@@ -64,10 +66,12 @@ export async function activate(context: vscode.ExtensionContext) {
 							panel.webview,
 							context
 						);
+						console.log('Add Folder!');
 						return;
 					case "renameFolder":
 						await renameFolder(message.oldFolderPath);
 						panel.webview.html = await updateWebview(message.parentFolder, message.parentPath, message.webviewToRender, panel.webview, context);
+						console.log('Rename!');
 						return;
 					case "addNote":
 						await addNote(message.destinationFolderName, message.destinationFolderUri, message.webviewToRender, context, panel);
@@ -78,6 +82,7 @@ export async function activate(context: vscode.ExtensionContext) {
 							panel.webview,
 							context
 						);
+						console.log('Add note!');
 						return;
 					case "save":
 						await saveFile(message.fileName, message.filePath, message.data.fileContent, context);
@@ -90,33 +95,41 @@ export async function activate(context: vscode.ExtensionContext) {
 						);
 						currentOpenFile = "";
 						currentOpenFilePath = "";
+						console.log('Save!');
 						return;
 					case "deleteFile":
 						await deleteFile(
 							message.fileName,
 							message.filePath,
-							context,
-							panel,
-							folders,
-							message.setPage,
-							message.currentFolderName,
-							message.currentFolderPath
+							context
 						);
+						panel.webview.html = await updateWebview(
+							message.currentFolderName,
+							message.currentFolderPath,
+							message.webviewToRender,
+							panel.webview,
+							context
+						);
+						console.log('Delete file!');
 						return;
 					case "deleteFolder":
 						await deleteFolder(
 							message.folderName,
 							message.folderPath,
-							context,
-							panel,
-							message.setPage,
-							message.currentFolderName,
-							message.currentFolderPath,
-							files
-							);	
+							context
+							);
+							panel.webview.html = await updateWebview(
+								message.currentFolderName,
+								message.currentFolderPath,
+								message.webviewToRender,
+								panel.webview,
+								context
+							);
+						console.log('Delete folder!');
 						return;
 					case "comment":
 						addDecoratorToLine(panel.webview, context, message.fileName, message.filePath);
+						console.log('Link code inside note!');
 				}
 			},
 			undefined,

--- a/src/utils/deleteFolder.ts
+++ b/src/utils/deleteFolder.ts
@@ -1,8 +1,5 @@
 import * as vscode from "vscode";
 import * as fse from "fs-extra";
-import { getWebviewOverview } from "../components/overview/overview";
-import { getWebviewSubfolder } from "../components/subfolder/subfolder";
-import { getFolderContents } from "./initialize";
 
 interface Files {
     dateCreated: string,
@@ -14,35 +11,10 @@ interface Files {
     uriPath: string
 }
 
-async function updateWebview(
-	setPage: string,
-	panel: vscode.WebviewPanel,
-	context: vscode.ExtensionContext,
-	currentFolderName: string,
-	currentFolderPath: string,
-	files: Files[]
-) {
-	const updatedFolders = await getFolderContents(context);
-	const updatedFolder = { folderName: currentFolderName, uriPath: currentFolderPath };
-
-	if (setPage === "overview") {
-		panel.webview.html = await getWebviewOverview(panel.webview, context, updatedFolders, files);
-	} else if (setPage === "subfolder") {
-		panel.webview.html = await getWebviewSubfolder(updatedFolder, panel.webview, context);
-	} else {
-		vscode.window.showErrorMessage("Error rendering page");
-	}
-}
-
 export async function deleteFolder(
 	folderName: string,
 	folderPath: string,
-	context: vscode.ExtensionContext,
-	panel: vscode.WebviewPanel,
-	setPage: string,
-	currentFolderName: string,
-	currentFolderPath: string,
-	files: Files[]
+	context: vscode.ExtensionContext
 ): Promise<void> {
 	try {
 		if (await fse.pathExists(folderPath)) {
@@ -52,7 +24,6 @@ export async function deleteFolder(
 			vscode.window.showErrorMessage(`Folder ${folderName} not found.`);
 		}
 
-		await updateWebview(setPage, panel, context, currentFolderName, currentFolderPath, files);
 	} catch (error: any) {
 		vscode.window.showErrorMessage(`Error deleting folder: ${error.message}`);
 	}

--- a/src/utils/deleteNote.ts
+++ b/src/utils/deleteNote.ts
@@ -1,38 +1,21 @@
 import * as vscode from 'vscode';
 import * as fse from 'fs-extra';
-import { getWebviewOverview } from '../components/overview/overview';
-import { getWebviewSubfolder } from '../components/subfolder/subfolder';
-import { getNotes } from './getLastEditedNotes';
 
 interface Folders {
 	folderName: string;
 	uriPath: string;
 }
 
-async function updateWebview(setPage: string, panel: vscode.WebviewPanel, context: vscode.ExtensionContext, folders: Folders[], currentFolderName: string, currentFolderPath?: string) {
-    const updatedFiles = await getNotes(currentFolderName);
-	const updatedFolderDeleteFiles = { folderName: currentFolderName, uriPath: currentFolderPath || ''};
-
-    if (setPage === 'overview') {
-        panel.webview.html = await getWebviewOverview(panel.webview, context, folders, updatedFiles);
-    } else if (setPage === 'subfolder') {
-        panel.webview.html = await getWebviewSubfolder(updatedFolderDeleteFiles, panel.webview, context);
-    } else {
-        vscode.window.showErrorMessage("Error rendering page");
-    }
-}
-
-export async function deleteFile(fileName: string, filePath: string, context: vscode.ExtensionContext, panel: vscode.WebviewPanel, folders: Folders[], setPage: string, currentFolderName: string, currentFolderPath?: string): Promise<void> {
+export async function deleteFile(fileName: string, filePath: string, context: vscode.ExtensionContext): Promise<void> {
     try {
             if (await fse.pathExists(filePath)) {
                 fse.unlink(filePath);
-                vscode.window.showInformationMessage(`File ${fileName} deleted successfully.`);
+                vscode.window.showInformationMessage(`File deleted successfully.`);
             } else {
-                vscode.window.showErrorMessage(`File ${fileName} not found.`);
+                vscode.window.showErrorMessage(`File not found.`);
             }
 
-            await updateWebview(setPage, panel, context, folders, currentFolderName, currentFolderPath);
-    } catch (error: any) {
+        } catch (error: any) {
         vscode.window.showErrorMessage(`Error deleting file: ${error.message}`);
     }
 }

--- a/src/utils/deleteNote.ts
+++ b/src/utils/deleteNote.ts
@@ -31,7 +31,7 @@ export async function deleteFile(fileName: string, filePath: string, context: vs
                 vscode.window.showErrorMessage(`File ${fileName} not found.`);
             }
 
-            await updateWebview(setPage, panel, context, folders, currentFolderName, currentFolderPath)
+            await updateWebview(setPage, panel, context, folders, currentFolderName, currentFolderPath);
     } catch (error: any) {
         vscode.window.showErrorMessage(`Error deleting file: ${error.message}`);
     }

--- a/src/utils/header.ts
+++ b/src/utils/header.ts
@@ -17,5 +17,5 @@ export async function header(webview: vscode.Webview, context: vscode.ExtensionC
             <link rel="stylesheet" href="${generalStyles}">
             <link rel="stylesheet" href="${codiconsUri}">
         </head>
-    `
+    `;
 }

--- a/src/utils/script.js
+++ b/src/utils/script.js
@@ -51,11 +51,29 @@ function list(data = [], sourcePath) {
 
 function clickOnFolder(option, folder, sourcePath) {
 	option.addEventListener("click", () => {
-		vscode.postMessage({
-			command: "move",
-			pathTo: folder.uriPath,
-			pathFrom: sourcePath,
-		});
+		const entryFolderPath = sourcePath.substr(0, sourcePath.lastIndexOf("entry")) + 'entry';
+		const entryFolderName = 'entry.entry';
+		const parentPath = sourcePath.substr(0, sourcePath.lastIndexOf("/"));
+		const parentFolder = parentPath.substr(parentPath.lastIndexOf("/") + 1);
+		if (parentFolder === entryFolderName ) {
+			vscode.postMessage({
+				command: "move",
+				pathTo: folder.uriPath,
+				pathFrom: sourcePath,
+				destinationFolderName: entryFolderName,
+				destinationFolderUri: entryFolderPath,
+				webviewToRender: 'overview'
+			});
+		} else {
+			vscode.postMessage({
+				command: "move",
+				pathTo: folder.uriPath,
+				pathFrom: sourcePath,
+				destinationFolderName: parentFolder,
+				destinationFolderUri: parentPath,
+				webviewToRender: 'subfolder'
+			});
+		}
 	});
 }
 

--- a/src/utils/script.js
+++ b/src/utils/script.js
@@ -53,15 +53,15 @@ function clickOnFolder(option, folder, sourcePath) {
 	option.addEventListener("click", () => {
 		const entryFolderPath = sourcePath.substr(0, sourcePath.lastIndexOf("entry")) + 'entry';
 		const entryFolderName = 'entry.entry';
-		const parentPath = sourcePath.substr(0, sourcePath.lastIndexOf("/"));
-		const parentFolder = parentPath.substr(parentPath.lastIndexOf("/") + 1);
-		if (parentFolder === entryFolderName ) {
+		const currentPath = sourcePath.substr(0, sourcePath.lastIndexOf("/"));
+		const currentFolder = currentPath.substr(currentPath.lastIndexOf("/") + 1);
+		if (currentPath === entryFolderPath && currentFolder === entryFolderName) {
 			vscode.postMessage({
 				command: "move",
 				pathTo: folder.uriPath,
 				pathFrom: sourcePath,
-				destinationFolderName: entryFolderName,
-				destinationFolderUri: entryFolderPath,
+				destinationFolderName: currentFolder,
+				destinationFolderUri: currentPath,
 				webviewToRender: 'overview'
 			});
 		} else {
@@ -69,8 +69,8 @@ function clickOnFolder(option, folder, sourcePath) {
 				command: "move",
 				pathTo: folder.uriPath,
 				pathFrom: sourcePath,
-				destinationFolderName: parentFolder,
-				destinationFolderUri: parentPath,
+				destinationFolderName: currentFolder,
+				destinationFolderUri: currentPath,
 				webviewToRender: 'subfolder'
 			});
 		}

--- a/src/utils/scriptImport.ts
+++ b/src/utils/scriptImport.ts
@@ -10,5 +10,5 @@ export async function scriptImport(webview: vscode.Webview, context: vscode.Exte
         <script>
 	        updateTheme(${isDark});
         </script>
-    `
+    `;
 }

--- a/src/utils/updateWebview.ts
+++ b/src/utils/updateWebview.ts
@@ -5,15 +5,23 @@ import { getWebviewSubfolder } from "../components/subfolder/subfolder";
 import { getNotes } from './getLastEditedNotes';
 
 export async function updateWebview(destinationFolderName: string, destinationFolderUri: string, webviewToRender: string, panel: vscode.Webview, context: vscode.ExtensionContext): Promise<string> {
-	const updatedFolder = { folderName: destinationFolderName, uriPath: destinationFolderUri };
-	const updatedFolders = await getFolderContents(context);
-	const lastEditedNotes = await getNotes(context.globalStorageUri.fsPath);
 
-	if (webviewToRender === 'subfolder') {
-		return await getWebviewSubfolder(updatedFolder, panel, context);
-	} else if (webviewToRender === 'overview') {
+	try {
+		const updatedFolder = { folderName: destinationFolderName, uriPath: destinationFolderUri };
+		const updatedFolders = await getFolderContents(context);
+		const lastEditedNotes = await getNotes(context.globalStorageUri.fsPath);
+
+		if (webviewToRender === 'subfolder') {
+			return await getWebviewSubfolder(updatedFolder, panel, context);
+		} else if (webviewToRender === 'overview') {
+			return await getWebviewOverview(panel, context, updatedFolders, lastEditedNotes);
+		} else {
+			return 'There was an error rendering the webview. Please try again or reload the extension if the issue persists.';
+		}
+	} catch (error) {
+		const updatedFolders = await getFolderContents(context);
+		const lastEditedNotes = await getNotes(context.globalStorageUri.fsPath);
+		console.log('Error updating the webview: ', error);		
 		return await getWebviewOverview(panel, context, updatedFolders, lastEditedNotes);
-	} else {
-		return 'There was an error rendering the webview. Please try again or reload the extension if the issue persists.';
-	}
+	};
 }

--- a/src/utils/updateWebview.ts
+++ b/src/utils/updateWebview.ts
@@ -14,6 +14,6 @@ export async function updateWebview(destinationFolderName: string, destinationFo
 	} else if (webviewToRender === 'overview') {
 		return await getWebviewOverview(panel, context, updatedFolders, lastEditedNotes);
 	} else {
-		return 'There was an error rendering the webview.';
+		return 'There was an error rendering the webview. Please try again or reload the extension if the issue persists.';
 	}
 }


### PR DESCRIPTION
**Add dynamic update of webview after moving, deleting, or navigating using back-button or breadcrumb link (update after add folder/note, rename folder and save is already implemented in the extension from earlier on).**

_Issue updating when moving a file or folder_

* Updating works correctly if the move-action is taken while on a Subfolder page, however, when the action is taken from the Overview page, it throws an error. The most likely cause is probably that the file is moved,  and then the updateWebview() throws an error due to the file not existing anymore, but I'm not 100% sure.

* Also, if moving a note from the Overview page, it'll currently render the Subfolder page of the folder it was moved to, instead of updating the Overview page.

* As of now I've made it fall back to show the Overview page when an error is thrown, so even if it does not work properly, it gives the appearance that it does.